### PR TITLE
Shared pref device descriptor

### DIFF
--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIAPIAdapter.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIAPIAdapter.java
@@ -17,10 +17,8 @@
 package com.ibm.pisdk;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
-import android.provider.Settings;
 import android.util.Base64;
 
 import com.ibm.json.java.JSONArray;
@@ -33,14 +31,15 @@ import com.ibm.pisdk.doctypes.PISensor;
 import com.ibm.pisdk.doctypes.PISite;
 import com.ibm.pisdk.doctypes.PIZone;
 
-import org.altbeacon.beacon.Beacon;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collection;
 
 /**
  * This class provides an interface with the Presence Insights APIs.

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIAPIAdapter.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIAPIAdapter.java
@@ -17,8 +17,10 @@
 package com.ibm.pisdk;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
+import android.provider.Settings;
 import android.util.Base64;
 
 import com.ibm.json.java.JSONArray;
@@ -31,11 +33,14 @@ import com.ibm.pisdk.doctypes.PISensor;
 import com.ibm.pisdk.doctypes.PISite;
 import com.ibm.pisdk.doctypes.PIZone;
 
+import org.altbeacon.beacon.Beacon;
+
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * This class provides an interface with the Presence Insights APIs.
@@ -58,9 +63,6 @@ public class PIAPIAdapter implements Serializable {
     static final private int READ_TIMEOUT_IN_MILLISECONDS = 7000; /* milliseconds */
     static final private int CONNECTION_TIMEOUT_IN_MILLISECONDS = 7000; /* milliseconds */
 
-    // mContext will be nice to have if we want to do any kind of UI actions for them.  For example,
-    // we could provide them the option to throw up a progress indicator while the async tasks are running.
-    private final transient Context mContext;
     private final String mServerURL;
     private final String mServerURL_v2;
     private final String mConnectorURL;
@@ -79,8 +81,7 @@ public class PIAPIAdapter implements Serializable {
      * @param tenantCode unique identifier for the tenant
      * @param orgCode unique identifier for the organization
      */
-    public PIAPIAdapter(Context context, String username, String password, String hostname, String tenantCode, String orgCode){
-        mContext = context;
+    public PIAPIAdapter(Context context, String username, String password, String hostname, String tenantCode, String orgCode) {
         mBasicAuth = generateBasicAuth(username, password);
         mServerURL = hostname + MANAGEMENT_SERVER_PATH;
         mServerURL_v2 = hostname + MANAGEMENT_SERVER_PATH_v2;

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensor.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensor.java
@@ -23,7 +23,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
-import android.provider.Settings;
 import android.support.v4.content.LocalBroadcastManager;
 
 import org.altbeacon.beacon.Beacon;

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensor.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensor.java
@@ -42,7 +42,6 @@ public class PIBeaconSensor {
 
     protected static final String INTENT_PARAMETER_ADAPTER = "com.ibm.pisdk.adapter";
     protected static final String INTENT_PARAMETER_COMMAND = "com.ibm.pisdk.command";
-    protected static final String INTENT_PARAMETER_DEVICE_ID = "com.ibm.pisdk.device_id";
     protected static final String INTENT_PARAMETER_BEACON_LAYOUT = "com.ibm.pisdk.beacon_layout";
     protected static final String INTENT_PARAMETER_SEND_INTERVAL = "com.ibm.pisdk.send_interval";
     protected static final String INTENT_PARAMETER_BACKGROUND_SCAN_PERIOD = "com.ibm.pisdk.send_interval";
@@ -59,7 +58,6 @@ public class PIBeaconSensor {
     private BluetoothAdapter mBluetoothAdapter;
     private final Context mContext;
     private final PIAPIAdapter mAdapter;
-    private final String mDeviceId;
 
     private String mState;
     private static final String STARTED = "started";
@@ -135,10 +133,6 @@ public class PIBeaconSensor {
         mBeaconsInRangeListener = null;
         mRegionEventListener = null;
 
-        // get Device ID
-        mDeviceId = Settings.Secure.getString(context.getContentResolver(),
-                Settings.Secure.ANDROID_ID);
-
         try {
 
             // If BLE isn't supported on the device we cannot proceed.
@@ -178,7 +172,6 @@ public class PIBeaconSensor {
 
         Intent intent = new Intent(mContext, PIBeaconSensorService.class);
         intent.putExtra(INTENT_PARAMETER_ADAPTER, mAdapter);
-        intent.putExtra(INTENT_PARAMETER_DEVICE_ID, mDeviceId);
         intent.putExtra(INTENT_PARAMETER_COMMAND, "START_SCANNING");
         mContext.startService(intent);
     }

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensorService.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIBeaconSensorService.java
@@ -112,7 +112,7 @@ public class PIBeaconSensorService extends Service implements BeaconConsumer {
                 mBeaconManager.setBackgroundBetweenScanPeriod(mBackgroundBetweenScanPeriod);
             }
             if (!extras.getString(PIBeaconSensor.INTENT_PARAMETER_COMMAND, "").equals("")) {
-                command = extras.getString(PIBeaconSensor.INTENT_PARAMETER_COMMAND);
+                command = extras.getString(PIBeaconSensor.INTENT_PARAMETER_COMMAND, "");
                 if (command.equals("START_SCANNING")){
                     PILogger.d(TAG, "Service has started scanning for beacons");
                     mBeaconManager.bind(this);
@@ -138,8 +138,6 @@ public class PIBeaconSensorService extends Service implements BeaconConsumer {
 
         mDeviceDescriptor = sharedPrefs.getString(PIDeviceInfo.PI_SHARED_PREF_DESCRIPTOR_KEY, "");
         if ("".equals(mDeviceDescriptor)) {
-            PILogger.d(TAG, "Descriptor does not exist is SharedPrefs, adding ANDROID_ID");
-
             String android_id = Settings.Secure.getString(mContext.getContentResolver(),
                     Settings.Secure.ANDROID_ID);
             mDeviceDescriptor = android_id;
@@ -157,7 +155,6 @@ public class PIBeaconSensorService extends Service implements BeaconConsumer {
                 @Override
                 public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
                     if (key.equals(PIDeviceInfo.PI_SHARED_PREF_DESCRIPTOR_KEY)) {
-                        PILogger.d(TAG, "descriptor changed listener hit!");
                         mDeviceDescriptor = sharedPreferences.getString(key, "");
                     }
                 }

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIDeviceInfo.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIDeviceInfo.java
@@ -17,6 +17,7 @@
 package com.ibm.pisdk;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.provider.Settings;
 
 import com.ibm.json.java.JSONObject;
@@ -27,6 +28,7 @@ import com.ibm.json.java.JSONObject;
  * @author Ciaran Hannigan (cehannig@us.ibm.com)
  */
 public class PIDeviceInfo {
+    static final String TAG = PIDeviceInfo.class.getSimpleName();
     static final String JSON_REGISTRATION_TYPE = "registrationType";
     static final String JSON_DEVICE_DESCRIPTOR = "descriptor";
     static final String JSON_NAME = "name";
@@ -34,6 +36,10 @@ public class PIDeviceInfo {
     static final String JSON_UNENCRYPTED_DATA = "unencryptedData";
     static final String JSON_REGISTERED = "registered";
     static final String JSON_BLACKLIST = "blacklist";
+
+    // shared prefs
+    protected static final String PI_SHARED_PREF = "com.ibm.pisdk.shared_prefs";
+    protected static final String PI_SHARED_PREF_DESCRIPTOR_KEY = "device_descriptor";
 
     private String mName;
     private String mDeviceDescriptor;
@@ -47,27 +53,30 @@ public class PIDeviceInfo {
      * Constructor for anonymous devices. This constructor will use ANDROID_ID as the
      * descriptor for the device.
      *
-     * @param context needed to generate the descriptor for the device
+     * @param context
      */
     public PIDeviceInfo(Context context) {
         mDeviceDescriptor = Settings.Secure.getString(context.getContentResolver(),
                 Settings.Secure.ANDROID_ID);
+        updateDeviceDescriptor(context);
     }
 
     /**
      * Constructor for anonymous devices with custom descriptors.
      *
+     * @param context
      * @param deviceDescriptor device descriptor used to uniquely identify the device
      */
-    public PIDeviceInfo(String deviceDescriptor) {
+    public PIDeviceInfo(Context context, String deviceDescriptor) {
         mDeviceDescriptor = deviceDescriptor;
+        updateDeviceDescriptor(context);
     }
 
     /**
      * Constructor for devices you plan on registering. This constructor will use ANDROID_ID as the
      * descriptor for the device.
      *
-     * @param context needed to generate the descriptor for the device
+     * @param context
      * @param name name of device
      * @param registrationType device registration type
      */
@@ -77,21 +86,34 @@ public class PIDeviceInfo {
         mRegistered = true;
         mDeviceDescriptor = Settings.Secure.getString(context.getContentResolver(),
                 Settings.Secure.ANDROID_ID);
+        updateDeviceDescriptor(context);
     }
 
     /**
      * Constructor, for devices you plan on registering, which allows you to specify your own
      * unique descriptor for this device.
      *
+     * @param context
      * @param name name of device
      * @param registrationType device registration type
      * @param deviceDescriptor device descriptor used to uniquely identify the device
      */
-    public PIDeviceInfo(String name, String registrationType, String deviceDescriptor) {
+    public PIDeviceInfo(Context context, String name, String registrationType, String deviceDescriptor) {
         mName = name;
         mRegistrationType = registrationType;
         mRegistered = true;
         mDeviceDescriptor = deviceDescriptor;
+
+        updateDeviceDescriptor(context);
+    }
+
+    private void updateDeviceDescriptor(Context context) {
+        PILogger.d(TAG, "the user registered the device with a new descriptor: " + mDeviceDescriptor);
+
+        SharedPreferences sharedPreferences = context.getSharedPreferences(PI_SHARED_PREF, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString(PI_SHARED_PREF_DESCRIPTOR_KEY, mDeviceDescriptor);
+        editor.apply();
     }
 
     /**

--- a/pi-sdk/src/main/java/com/ibm/pisdk/PIDeviceInfo.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/PIDeviceInfo.java
@@ -108,8 +108,6 @@ public class PIDeviceInfo {
     }
 
     private void updateDeviceDescriptor(Context context) {
-        PILogger.d(TAG, "the user registered the device with a new descriptor: " + mDeviceDescriptor);
-
         SharedPreferences sharedPreferences = context.getSharedPreferences(PI_SHARED_PREF, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(PI_SHARED_PREF_DESCRIPTOR_KEY, mDeviceDescriptor);

--- a/pi-sdk/src/main/java/com/ibm/pisdk/doctypes/PIDevice.java
+++ b/pi-sdk/src/main/java/com/ibm/pisdk/doctypes/PIDevice.java
@@ -17,7 +17,6 @@
 package com.ibm.pisdk.doctypes;
 
 import com.ibm.json.java.JSONObject;
-import com.ibm.pisdk.PILogger;
 
 /**
  * Simple class to encapsulate the Device documents important attributes.


### PR DESCRIPTION
When creating a PIDeviceInfo, we now will store the descriptor in shared prefs to be accessible by the beacon sensor. If the user starts the beacon sensor before registering a device, we will fill the shared pref with a default descriptor (ANDROID_ID).
